### PR TITLE
Adds systemproperties and additionalpluginfiles

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
                                     <com.sun.management.jmxremote.ssl>false</com.sun.management.jmxremote.ssl>
                                 </systemPropertyVariables>
                                 <additionalPluginFiles>
-                                    <additionalPluginFile>../hivemq/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
+                                    <additionalPluginFile><1>/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
                                 </additionalPluginFiles>
                                 <!-- /activate jmx -->
                             </configuration>

--- a/README.adoc
+++ b/README.adoc
@@ -33,14 +33,11 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
                                 <hiveMQDir>
                                        <1>
                                 </hiveMQDir>
-                                <!-- e.g. activate jmx -->
+                                
                                 <systemPropertyVariables>
-                                    <com.sun.management.jmxremote/>
-                                    <com.sun.management.jmxremote.port>9010</com.sun.management.jmxremote.port>
-                                    <com.sun.management.jmxremote.local.only>false</com.sun.management.jmxremote.local.only>
-                                    <com.sun.management.jmxremote.authenticate>false</com.sun.management.jmxremote.authenticate>
-                                    <com.sun.management.jmxremote.ssl>false</com.sun.management.jmxremote.ssl>
+                                    <foo>bar</foo>
                                 </systemPropertyVariables>
+                                <!-- e.g. activate jmx -->
                                 <additionalPluginFiles>
                                     <additionalPluginFile><hiveMQDir>/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
                                 </additionalPluginFiles>

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
                                     <com.sun.management.jmxremote.ssl>false</com.sun.management.jmxremote.ssl>
                                 </systemPropertyVariables>
                                 <additionalPluginFiles>
-                                    <additionalPluginFile><1>/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
+                                    <additionalPluginFile><hiveMQDir>/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
                                 </additionalPluginFiles>
                                 <!-- /activate jmx -->
                             </configuration>

--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,10 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
                                 <hiveMQDir>
                                        <1>
                                 </hiveMQDir>
+                                <systemPropertyVariables>
+                                    <!-- -DdiagnosticMode=true -->
+                                    <diagnosticMode>true</diagnosticMode>
+                                </systemPropertyVariables>
                             </configuration>
                         </execution>
                     </executions>
@@ -108,6 +112,12 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
 |false
 |hivemq.jar
 |Name of the HiveMQ Jar-file
+
+|systemPropertyVariables
+|String
+|false
+|
+|List of system properties propagated to HiveMQ on startup
 
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -33,10 +33,18 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
                                 <hiveMQDir>
                                        <1>
                                 </hiveMQDir>
+                                <!-- e.g. activate jmx -->
                                 <systemPropertyVariables>
-                                    <!-- -DdiagnosticMode=true -->
-                                    <diagnosticMode>true</diagnosticMode>
+                                    <com.sun.management.jmxremote/>
+                                    <com.sun.management.jmxremote.port>9010</com.sun.management.jmxremote.port>
+                                    <com.sun.management.jmxremote.local.only>false</com.sun.management.jmxremote.local.only>
+                                    <com.sun.management.jmxremote.authenticate>false</com.sun.management.jmxremote.authenticate>
+                                    <com.sun.management.jmxremote.ssl>false</com.sun.management.jmxremote.ssl>
                                 </systemPropertyVariables>
+                                <additionalPluginFiles>
+                                    <additionalPluginFile>../hivemq/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
+                                </additionalPluginFiles>
+                                <!-- /activate jmx -->
                             </configuration>
                         </execution>
                     </executions>
@@ -118,6 +126,12 @@ This maven plugin simplifies the development of HiveMQ plugins as it provides a 
 |false
 |
 |List of system properties propagated to HiveMQ on startup
+
+|additionalPluginFiles
+|File
+|false
+|
+|List of additional hivemq plugin files used by HiveMQ
 
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.hivemq</groupId>
     <artifactId>hivemq-maven-plugin</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>HiveMQ Maven Plugin</name>

--- a/src/main/java/com/hivemq/maven/HiveMQMojo.java
+++ b/src/main/java/com/hivemq/maven/HiveMQMojo.java
@@ -34,8 +34,10 @@ import org.stringtemplate.v4.ST;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.*;
 
 /**
  * @author Christian Götz
@@ -74,6 +76,8 @@ public class HiveMQMojo extends AbstractMojo {
     File hiveMQDir;
     @Parameter(defaultValue = "hivemq.jar", property = "hivemqJar", required = true)
     String hivemqJar;
+    @Parameter
+    Map<String, String> systemPropertyVariables;
 
     /**
      * {@inheritDoc}
@@ -189,12 +193,27 @@ public class HiveMQMojo extends AbstractMojo {
             commands.add(debugFolder.get());
 
         }
+        commands.addAll(getSystemProperties());
         commands.add("-Dhivemq.home=" + hiveMQDir.getAbsolutePath());
         commands.add("-noverify");
         commands.add("-jar");
         commands.add(hivemqJarFile.getAbsolutePath());
 
         return commands;
+    }
+
+    /**
+     * @return a list of systemproperty strings matching "-D%key%=%value%
+     */
+    @VisibleForTesting
+    List<String> getSystemProperties() {
+        final List<String> systemProperties = newArrayList();
+        if (systemPropertyVariables != null) {
+            for (Map.Entry<String, String> systemPropertyEntry : systemPropertyVariables.entrySet()) {
+                systemProperties.add(format("-D%s=%s", systemPropertyEntry.getKey() , systemPropertyEntry.getValue()));
+            }
+        }
+        return systemProperties;
     }
 
     /**

--- a/src/test/java/com/hivemq/maven/HiveMQMojoTest.java
+++ b/src/test/java/com/hivemq/maven/HiveMQMojoTest.java
@@ -24,8 +24,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.util.List;
 
+import static com.google.common.collect.Maps.newHashMap;
 import static org.assertj.guava.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -78,6 +81,23 @@ public class HiveMQMojoTest {
         assertThat(tempPluginFolder).isPresent().contains("-Dhivemq.plugin.folder=" + debugFolder.getAbsolutePath());
 
         assertEquals(1, debugFolder.list().length);
+    }
+
+    @Test
+    public void should_build_correct_systemproperty_string(){
+        //Given
+        final HiveMQMojo hiveMQMojo = new HiveMQMojo();
+        hiveMQMojo.systemPropertyVariables = newHashMap();
+
+        //When
+        hiveMQMojo.systemPropertyVariables.put("foo", "1");
+        hiveMQMojo.systemPropertyVariables.put("bar", "2");
+        final List<String> systemProperties = hiveMQMojo.getSystemProperties();
+
+        //Then
+        assertEquals(2, systemProperties.size());
+        assertTrue(systemProperties.contains("-Dfoo=1"));
+        assertTrue(systemProperties.contains("-Dbar=2"));
     }
 
     @Test

--- a/src/test/java/com/hivemq/maven/HiveMQMojoTest.java
+++ b/src/test/java/com/hivemq/maven/HiveMQMojoTest.java
@@ -24,6 +24,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -123,4 +124,31 @@ public class HiveMQMojoTest {
         hiveMQMojo.getHiveMQJarFile(file);
     }
 
+    @Test
+    public void test_should_not_copy_files_when_additionalPluginFiles_is_null()
+            throws MojoExecutionException, IOException {
+        final File[] files = null;
+        int filesExpected = 0;
+
+        assertCopyAdditionalPluginFiles(files, filesExpected);
+    }
+
+    @Test
+    public void test_should_copy_additionalPluginFiles() throws MojoExecutionException, IOException {
+        final File[] files = new File[] { temporaryFolder.newFile(), temporaryFolder.newFile() };
+        int filesExpected = 2;
+
+        assertCopyAdditionalPluginFiles(files, filesExpected);
+    }
+
+    private void assertCopyAdditionalPluginFiles(final File[] files, final int filesExpected)
+            throws IOException, MojoExecutionException {
+        final File tempFolder = temporaryFolder.newFolder();
+
+        final HiveMQMojo hiveMQMojo = new HiveMQMojo();
+        hiveMQMojo.additionalPluginFiles = files;
+        hiveMQMojo.copyAdditionalPluginFiles(tempFolder);
+
+        assertEquals(filesExpected, tempFolder.list().length);
+    }
 }


### PR DESCRIPTION
Adds systemproperties and additionalpluginfiles to HiveMQMojo so that it is possible to use default HiveMQ plugins such as jmx.

```
<configuration>
    <systemPropertyVariables>
        <foo>bar</foo>
    </systemPropertyVariables>
    <additionalPluginFiles>
        <additionalPluginFile>../hivemq/plugins/hivemq-jmx-metrics-plugin-3.1.0.jar</additionalPluginFile>
    </additionalPluginFiles>
</configuration>
```