### PR TITLE
Change JDKs used for Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: java
 
 jdk:
   - openjdk7
-  - openjdk6
+  - openjdk8
+  - openjdk9


### PR DESCRIPTION
Changes the JDK for the Travis Build to JDK 7,8,9 since JDK 6 is not supported by current HiveMQ versions